### PR TITLE
Add docker-compose.yml for PostgreSQL and Redis services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: store_development
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
This pull request adds a new `docker-compose.yml` file to the project, providing an easy way to spin up required development services using Docker.

Development environment setup:

* Added a `docker-compose.yml` file that defines services for `postgres` and `redis`, including default environment variables and port mappings for local development.